### PR TITLE
feat: handle additional Stripe webhook events and cleanup failed orders

### DIFF
--- a/src/main/java/com/academy/e_commerce/controller/PaymentController.java
+++ b/src/main/java/com/academy/e_commerce/controller/PaymentController.java
@@ -3,6 +3,8 @@ package com.academy.e_commerce.controller;
 import com.academy.e_commerce.advice.UnauthorizedAccessException;
 import com.academy.e_commerce.model.Order;
 import com.academy.e_commerce.repository.OrderRepository;
+import com.academy.e_commerce.service.OrderService;
+import com.academy.e_commerce.service.PaymentService;
 import com.stripe.exception.StripeException;
 import com.stripe.model.PaymentIntent;
 import com.stripe.param.PaymentIntentCreateParams;
@@ -23,27 +25,15 @@ import java.util.Map;
 public class PaymentController {
 
     private final OrderRepository orderRepository;
+    private final PaymentService paymentService;
 
     @PostMapping("/{userId}/pay/{orderId}")
     public ResponseEntity<Map<String, String>> createPaymentIntent(
             @PathVariable Long userId,
             @PathVariable Long orderId) throws StripeException {
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
 
-        if (order.getUser() == null || !order.getUser().getId().equals(userId)) {
-            throw new UnauthorizedAccessException("You are not authorized to pay for this order.");
-        }
-
-        PaymentIntentCreateParams params = PaymentIntentCreateParams.builder()
-                .setAmount(BigDecimal.valueOf(order.getTotalPrice()).multiply(BigDecimal.valueOf(100)).longValue())
-                .setCurrency("usd")
-                .putMetadata("order_id", String.valueOf(orderId))
-                .build();
-
-        PaymentIntent intent = PaymentIntent.create(params);
-
-        return ResponseEntity.ok(Map.of("clientSecret", intent.getClientSecret()));
+        Map<String, String> response = paymentService.createPaymentIntent(userId, orderId);
+        return ResponseEntity.ok(response);
     }
 
     // dummy endpoint for testing from backend

--- a/src/main/java/com/academy/e_commerce/service/PaymentService.java
+++ b/src/main/java/com/academy/e_commerce/service/PaymentService.java
@@ -1,0 +1,43 @@
+package com.academy.e_commerce.service;
+
+import com.academy.e_commerce.advice.UnauthorizedAccessException;
+import com.academy.e_commerce.model.Order;
+import com.academy.e_commerce.repository.OrderRepository;
+import com.stripe.exception.StripeException;
+import com.stripe.model.PaymentIntent;
+import com.stripe.param.PaymentIntentCreateParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final OrderRepository orderRepository;
+    private final OrderService orderService;
+
+    public Map<String, String> createPaymentIntent(Long userId, Long orderId) throws StripeException {
+        orderService.confirmOrder(userId);
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new IllegalArgumentException("Order not found"));
+
+        if (order.getUser() == null || !order.getUser().getId().equals(userId)) {
+            throw new UnauthorizedAccessException("You are not authorized to pay for this order.");
+        }
+
+        PaymentIntentCreateParams params = PaymentIntentCreateParams.builder()
+                .setAmount(BigDecimal.valueOf(order.getTotalPrice()).multiply(BigDecimal.valueOf(100)).longValue())
+                .setCurrency("usd")
+                .putMetadata("order_id", String.valueOf(orderId))
+                .build();
+
+        PaymentIntent intent = PaymentIntent.create(params);
+
+        return Map.of("clientSecret", intent.getClientSecret());
+    }
+}
+

--- a/src/main/java/com/academy/e_commerce/service/PaymentWebhookService.java
+++ b/src/main/java/com/academy/e_commerce/service/PaymentWebhookService.java
@@ -13,11 +13,17 @@ import org.springframework.stereotype.Service;
 public class PaymentWebhookService {
 
     private final OrderRepository orderRepository;
+    private final OrderService orderService;
 
     public void handleEvent(Event event) {
+        String eventType = event.getType();
+        log.info("Received Stripe event: {}", eventType);
         switch (event.getType()) {
             case "payment_intent.succeeded":
                 handlePaymentSucceeded(event);
+                break;
+            case "payment_intent.payment_failed":
+                handlePaymentFailed(event);
                 break;
 
             default:
@@ -29,16 +35,40 @@ public class PaymentWebhookService {
         PaymentIntent intent = (PaymentIntent) event.getDataObjectDeserializer()
                 .getObject()
                 .orElseThrow(() -> new IllegalStateException("Failed to deserialize payment intent"));
+
+        String orderId = intent.getMetadata().get("order_id");
+        if (orderId != null){
+            updateOrderStatus(orderId, "PAID", "Payment succeeded");
+        } else {
+            log.warn("No order_id found in payment intent succeeded metadata.");
+        }
+    }
+
+    private void handlePaymentFailed(Event event) {
+        PaymentIntent intent = (PaymentIntent) event.getDataObjectDeserializer()
+                .getObject()
+                .orElseThrow(() -> new IllegalStateException("Failed to deserialize payment intent"));
+
         String orderId = intent.getMetadata().get("order_id");
 
         if (orderId != null) {
+            long parsedOrderId = Long.parseLong(orderId);
+            updateOrderStatus(orderId, "FAILED", "Payment failed");
+            orderService.removeOrder(parsedOrderId);
+        } else {
+            log.warn("No order_id found in payment intent failed metadata.");
+        }
+    }
+
+    private void updateOrderStatus(String orderId, String status, String logMessage) {
+        if (orderId != null) {
             orderRepository.findById(Long.parseLong(orderId)).ifPresent(order -> {
-                order.setStatus("PAID");
+                order.setStatus(status);
                 orderRepository.save(order);
-                log.info("Order ID {} marked as PAID.", orderId);
+                log.info("Order ID {} marked as {}. {}", orderId, status, logMessage);
             });
         } else {
-            log.warn("No order_id found in payment intent metadata.");
+            log.warn("No order_id found in metadata for status update.");
         }
     }
 }


### PR DESCRIPTION
- Added support for handling more Stripe webhook events including payment_intent.failed.
- On payment_intent.failed, the order status is updated to FAILED, and the order is rolled back via orderService.removeOrder().
- Improved logging and validation for metadata fields like order_id.